### PR TITLE
Closes associatedemployers/safely#4

### DIFF
--- a/api/classes/config.json
+++ b/api/classes/config.json
@@ -8,5 +8,4 @@
       "forceCompanyQueryMerge": false
     }
   }
-
 }

--- a/lib/abstractions/create.js
+++ b/lib/abstractions/create.js
@@ -27,7 +27,9 @@ module.exports = options => {
       payload.creator = this.user;
     }
 
-    if ( options.forceCompanyQueryMerge !== false && this.user && this.user.company ) {
+    const hasCompanyKey = !!Model.schema.path('company');
+
+    if (hasCompanyKey && options.forceCompanyQueryMerge !== false && this.user && this.user.company) {
       payload.company = this.user.company;
     }
 

--- a/lib/abstractions/destroy.js
+++ b/lib/abstractions/destroy.js
@@ -13,7 +13,9 @@ module.exports = options => {
 
     let q = { _id: id };
 
-    if ( options.forceCompanyQueryMerge !== false && this.user && this.user.administrative !== true ) {
+    const hasCompanyKey = !!Model.schema.path('company');
+
+    if (hasCompanyKey && options.forceCompanyQueryMerge !== false && this.user && this.user.administrative !== true) {
       q.company = this.user.company;
     }
 

--- a/lib/abstractions/index.js
+++ b/lib/abstractions/index.js
@@ -22,7 +22,9 @@ module.exports = ( options = {} ) => {
         skip       = page * limit,
         sort       = query.sort ? query.sort : options.sort ? options.sort : { created: 1 };
 
-    if ( options.forceCompanyQueryMerge !== false && this.user && this.user.company ) {
+    const hasCompanyKey = !!Model.schema.path('company');
+
+    if (hasCompanyKey && options.forceCompanyQueryMerge !== false && this.user && this.user.company) {
       query.company = this.user.company;
     }
 

--- a/lib/abstractions/show.js
+++ b/lib/abstractions/show.js
@@ -9,11 +9,12 @@ module.exports = options => {
       modelName = inflect.underscore(Model.modelName).toLowerCase();
 
   return function* () {
-    let id = this.params[modelName];
+    let id = this.params[modelName],
+        q = { _id: id };
 
-    let q = { _id: id };
+    const hasCompanyKey = !!Model.schema.path('company');
 
-    if ( options.forceCompanyQueryMerge !== false && this.user && this.user.company ) {
+    if (hasCompanyKey && options.forceCompanyQueryMerge !== false && this.user && this.user.company) {
       q[options.companyMergeKey || 'company'] = this.user.company;
     }
 

--- a/lib/abstractions/update.js
+++ b/lib/abstractions/update.js
@@ -39,7 +39,9 @@ module.exports = options => {
 
     let q = { _id: id };
 
-    if ( options.forceCompanyQueryMerge !== false && this.user && this.user.administrative !== true ) {
+    const hasCompanyKey = !!Model.schema.path('company');
+
+    if (hasCompanyKey && options.forceCompanyQueryMerge !== false && this.user && this.user.administrative !== true) {
       q.company = this.user.company;
     }
 

--- a/lib/adapters/sql/index.js
+++ b/lib/adapters/sql/index.js
@@ -9,6 +9,10 @@ exports.mongoose = (schema, opts = { ops: [ 'create', 'update', 'remove' ] }) =>
     _import: Boolean
   });
 
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+
   schema.pre('save', function (next) {
     this.wasNew = this.isNew;
     this.skipSQLOps = this.isNew && this._import;

--- a/lib/models/blackout-date/index.js
+++ b/lib/models/blackout-date/index.js
@@ -16,6 +16,7 @@ var blackoutDateSchema = new Schema(_.extend(
   {
     start: Date,
     end: Date,
+    seats: Number,
 
     classExceptions: [{ type: Relationship, ref: 'Class' }],
     blocks: [[ Number ]]

--- a/lib/models/registration/middleware/assign-seat.js
+++ b/lib/models/registration/middleware/assign-seat.js
@@ -38,11 +38,12 @@ function middleware (next) {
   };
 
   let inBlackoutDate = function*(date, classes) {
-    let mdate = moment(date);
+    let mdate = moment(date),
+        block = yield findBlock(date);
 
     // Hit the db to see if we are in a user
     // set blackout date or block.
-    return !(yield findBlock(date))[1] || (yield BlackoutDate.findOne({
+    return !block[1] || (yield BlackoutDate.findOne({
       start: { $lte: date },
       end: { $gte: date },
       'classExceptions.0': { $exists: false }
@@ -59,8 +60,20 @@ function middleware (next) {
 
       let exceptions = _.map(Array.prototype.concat.apply([], _.map(blackouts, 'classExceptions')), b => b.toString()),
           _classes = _.map(classes, c => c._id.toString());
+
       // Make sure that all of the classes are in the exceptions
-      return _classes.filter(c => !_.includes(exceptions, c)).length > 0 ? blackouts[0] : false;
+      if (_classes.filter(c => !_.includes(exceptions, c)).length > 0) {
+        if (!blackouts[0].seats) {
+          return blackouts[0];
+        }
+
+        let qDate = mdate.toDate();
+
+        return Seat.countAvailableSeats(qDate, qDate, blackouts[0])
+        .then(count => count > 0 ? false : blackouts[0]);
+      }
+
+      return false;
     }));
   };
 
@@ -80,7 +93,9 @@ function middleware (next) {
     while (yield inBlackout()) {
       if (blackout.classExceptions && blackout.classExceptions.length > 0) {
         winston.debug('Blackout is a class-based blackout. Exiting with error.');
-        throw new Error('The classes you\'ve selected fall within a class-specific blackout date.');
+        let msg = 'The classes you\'ve selected fall within a class-specific blackout date.';
+        msg += blackout.seats ? ' There might not be enough seats to accomodate your registration.' : '';
+        throw new Error(msg);
       }
 
       yield incrementBlock(start);

--- a/lib/models/registration/test.js
+++ b/lib/models/registration/test.js
@@ -8,6 +8,7 @@ const chai          = require('chai'),
       AvailableTime = require('../available-time');
 
 require('../../load/winston')();
+require('../../..')();
 
 describe('Integration :: Registration Model', () => {
   let classes;
@@ -232,6 +233,63 @@ describe('Integration :: Registration Model', () => {
         expect(reg.times, `Expect registration #${i} to have length of 2`).to.have.lengthOf(2);
         yield reg.remove();
       }
+    });
+
+    it('should schedule with class blackouts (with seat # specified)', function*() {
+      // Create 10 seats
+      for (let i = 0; i < 10; i++) {
+        yield (new Seat({
+          number: i + 1
+        })).save();
+      }
+
+      // Create a new blackout with seats to reserve
+      yield (new BlackoutDate({
+        start: moment().day(1).startOf('day').toDate(),
+        end: moment().day(1).endOf('day').toDate(),
+        classExceptions: classes.slice(0, 2),
+        seats: 5,
+        blocks: [[8,10],[10,12]]
+      })).save();
+
+      let regs = [];
+
+      for (let i = 0; i < 6; i++) {
+        // The fifth one should encounter an error
+        if (i === 5) {
+          try {
+            yield (new Model({
+              start: moment().day(1).hour(8),
+              classes: [ classes[4] ]
+            })).save();
+          } catch (e) {
+            expect(e.message).to.contain('seats');
+            continue;
+          }
+
+          expect(true, 'Should have errored on creation of 6th seat').to.equal(false);
+        }
+
+        let r = yield (new Model({
+          start: moment().day(1).hour(8),
+          classes: [ classes[4] ]
+        })).save();
+
+        expect(r.times, `Expect registration #${i} times to have length of 1`).to.have.lengthOf(1);
+        regs.push(r);
+      }
+
+      // If we made it here, we should be able to create a new registration
+      // within the class blackout.
+      let lastReg = yield (new Model({
+        start: moment().day(1).hour(8),
+        classes: [ classes[0] ]
+      })).save();
+
+      expect(lastReg).to.exist;
+      //
+      // // Remove registrations
+      // yield regs.map(r => r.remove());
     });
   });
 });

--- a/lib/models/seat/statics/countAvailableSeats.js
+++ b/lib/models/seat/statics/countAvailableSeats.js
@@ -1,7 +1,9 @@
-const winston = require('winston'),
-      Registration = require('../../registration');
+const Registration = require('../../registration'),
+      toString = require('lodash/toString'),
+      map = require('lodash/map'),
+      find = require('lodash/find');
 
-module.exports = function (start, end) {
+module.exports = function (start, end, classBlackout) {
   return Registration.find({
     $or: [{
       cancelledOn: null
@@ -23,6 +25,21 @@ module.exports = function (start, end) {
       _id: { $nin: seats },
       inactive: { $ne: true }
     })
-    .exec();
+    .exec()
+    .then(count => {
+      if (!classBlackout || !classBlackout.seats) {
+        return count;
+      }
+
+      let classExceptions = map(classBlackout.classExceptions, toString);
+      // Filter to find the number of seats we need to disclude from
+      // the class specific reduction
+      let registeredInException = registrations.filter((reg) => {
+        return find(reg.classes, c => classExceptions.indexOf((c._id || c).toString()) > -1);
+      });
+
+      let toSubtract = (classBlackout.seats || 0) - (registeredInException.length || 0);
+      return count - (toSubtract || 0);
+    });
   });
 };


### PR DESCRIPTION
This PR will help close associatedemployers/safely#4 by:

- Adding seats to blackout models
- Adding tests for “less seats” when registering
- Modifying seat assignment to account for class blackout seats
- Modifying seat counter to account for class blackout seats
- Adding dynamic company key discovery
