### PR TITLE
[Enhancement] Add query support to booked resources route

### DIFF
--- a/api/hub-classes/index.js
+++ b/api/hub-classes/index.js
@@ -104,6 +104,14 @@ exports.bookedResources = async function (n, HubClass, compiledQuery) {
 
   let optionalStages = [];
 
+  if (query) {
+    optionalStages.push({
+      $match: {
+        ...query || {}
+      }
+    });
+  }
+
   if (sort) {
     optionalStages.push({
       $sort: {


### PR DESCRIPTION
Closes #78

**_Action_**
Requesting to merge branch `enhancement/#78-add-query-support-to-booked-resources-route` into `epic/training-room-registration`

**_Description_**
Query filters can be passed into the booked resources route. 