### PR TITLE
[Bug] Wrong company on hub registration

### DIFF
--- a/api/hub-registrations/index.js
+++ b/api/hub-registrations/index.js
@@ -33,7 +33,7 @@ exports.bookedResources = async function (n, HubRegistration, compiledQuery) {
 
   const hubRegistrations = await HubRegistration.aggregate([ {
     $match: {
-      $or:[ {
+      $or:[{
         participants
       }, {
         participants: { $type: 4 }
@@ -76,14 +76,14 @@ exports.bookedResources = async function (n, HubRegistration, compiledQuery) {
           participant: '$participants'
         },
       },
-      cancelledOn:{$first:'$cancelledOn'},
-      hubClass:{$first:'$hubClass'},
-      start:{$first:'$start'},
-      end:{$first:'$end'},
-      address:{$first:'$address'},
-      total:{$sum: '$total'},
-      isClassMember:{$first:'$isClassMember'},
-      po:{$push: {$ifNull:[null,'$po']}}
+      cancelledOn:   { $first:'$cancelledOn' },
+      hubClass:      { $first:'$hubClass' },
+      start:         { $first:'$start' },
+      end:           { $first:'$end' },
+      address:       { $first:'$address' },
+      total:         { $sum: '$total' },
+      isClassMember: { $first:'$isClassMember' },
+      po:            { $push: { $ifNull:[null,'$po'] } }
     }},{
     $addFields: {
       seatsLeft: { $subtract: [{ $first:'$hubClass.seats' }, { $size:'$participants' }] }
@@ -93,19 +93,19 @@ exports.bookedResources = async function (n, HubRegistration, compiledQuery) {
   }, {
     $replaceRoot: {
       newRoot: {
-        $mergeObjects: [ "$$ROOT", "$uniqueHRegs" ]
+        $mergeObjects: [ '$$ROOT', '$uniqueHRegs' ]
       }
     }
   }, {
     $lookup: {
-      from: "companies",
-      localField: "company",
-      foreignField: "_id",
-      as: 'c',
+      from:         'companies',
+      localField:   'company',
+      foreignField: '_id',
+      as:           'c',
       pipeline: [
         {
           $project: {
-            _id: 0,
+            _id:  0,
             name: 1,
           },
         },
@@ -114,7 +114,7 @@ exports.bookedResources = async function (n, HubRegistration, compiledQuery) {
   }, {
     $addFields: {
       companyName: {
-        $first: "$c.name",
+        $first: '$c.name',
       },
     }
   }, {


### PR DESCRIPTION
Closes #128

**_Action_**
Requesting to merge branch `bug/#128-wrong-company-on-hub-registration` into `master`

**_Description_**
• Updates the aggregate in bookedResources to persist unique company names and registrant names belonging to the hub-registrations. 
• Fetches the company belonging to the `company` (ID Property) and set's the companyName on the hub-registration.

**How to Reproduce this Bug**
See #128

Updated aggregate file for usage in MongoDB Compass: 
[updated_aggregate.json](https://github.com/associatedemployers/safely-api/files/14726554/updated_aggregate.json)

**_Images_**
The unique company names and registrants are now preserved with hub-registrations on the front end
<img width="1166" alt="Screenshot 2024-03-22 at 11 41 48 AM" src="https://github.com/associatedemployers/safely-api/assets/24633494/1603dfa3-edc8-4346-94d6-eb260e1f0ec5">

