### PR TITLE
[Enhancement] Add HubClassException to blackout-date model

### DIFF
--- a/api/blackout-dates/config.json
+++ b/api/blackout-dates/config.json
@@ -1,14 +1,14 @@
 {
   "name": "blackout_date",
   "description": "blackout date administrative resource endpoint",
-  "secure": true,
+  "securedOps": "cud",
   "authorizationOptions": {
     "administrative": true
   },
   "ops": "crud",
   "crudOptions": {
     "update": {
-      "explicitKeys": [ "blocks", "classExceptions" ]
+      "explicitKeys": [ "blocks", "classExceptions", "hubClassExceptions" ]
     }
   }
 }

--- a/lib/models/blackout-date/index.js
+++ b/lib/models/blackout-date/index.js
@@ -19,6 +19,7 @@ var blackoutDateSchema = new Schema(_.extend(
     seats: Number,
 
     classExceptions: [{ type: Relationship, ref: 'Class' }],
+    hubClassExceptions: [{ type: Relationship, ref: 'HubClass' }],
     blocks: [[ Number ]]
   },
   baseModel.base


### PR DESCRIPTION
Closes #135

Related to [Pull Request #202 - Add HUB Class Blackout](https://github.com/associatedemployers/safely/pull/202) on Safely F.E.

**_Action_**
Requesting to merge branch `enhancement/#135-add-hubclassexception-to-blackout-date-model` into `master`

**_Description_**
Adds a hubClassExceptions to the blackout model to be utilized by the front-end so that the user can use blackout configurations with the hub classes.

