### PR TITLE
[Feature] Add get generated times function to hub class

### DIFF
--- a/api/hub-classes/index.js
+++ b/api/hub-classes/index.js
@@ -1,4 +1,8 @@
 exports.withAvailability = async function (n, HubClass, compiledQuery) {
+  const moment = require('moment');
+  const { recur } = require('moment-recur');
+  const winston = require('winston');
+
   const {
     query,
     select,
@@ -74,7 +78,43 @@ exports.withAvailability = async function (n, HubClass, compiledQuery) {
     $project
   }]);
 
+  function getGeneratedTimes (cl) {
+    const REPEATER = 8;
+
+    if (!((cl || {}).generateTimeRef || {}).dayRef) {
+      winston.debug('generateTimes and generateTimeRef must be set before calling generatedTimes');
+      return [];
+    }
+
+    let nextDates = [];
+    let { dayRef, timeBlock } = cl.generateTimeRef;
+    if (dayRef) {
+      let today = moment().startOf('day');
+      let ref = recur(today).every(dayRef).daysOfWeek();
+
+      // Front-End Registrations Code Example
+      // Do not create a timeblock if there hub-class is full
+      nextDates = ref.next(REPEATER).reduce((acc, cur, index) => {
+        let startString = `${moment(cur).format('MM DD YYYY')} ${timeBlock.start.hour}:${timeBlock.start.min}`;
+        let endString = `${moment(cur).format('MM DD YYYY')} ${timeBlock.end.hour}:${timeBlock.end.min}`;
+
+        acc.push({
+          start: new Date(startString).toLocaleString('en', { timeZone: 'America/Denver' }),
+          end:   new Date(endString).toLocaleString('en', { timeZone: 'America/Denver' }),
+          _id:   index
+        });
+        return acc;
+      }, []);
+    }
+    return nextDates;
+  }
+
+  const hubClasses = hubClass.map(hbClass => {
+    hbClass.times.push(...getGeneratedTimes(hbClass));
+    return hbClass;
+  });
+ 
   return {
-    hubClass
+    hubClass: hubClasses
   };
 };

--- a/api/hub-classes/index.js
+++ b/api/hub-classes/index.js
@@ -110,7 +110,6 @@ exports.withAvailability = async function (n, HubClass, compiledQuery) {
         }, 0);
 
         if (participantCountForTimeblock >= cl.seats) {
-          acc.push({});
           return acc;
         }
 
@@ -131,7 +130,8 @@ exports.withAvailability = async function (n, HubClass, compiledQuery) {
       return hbClass;
     }
 
-    hbClass.times.push(...getGeneratedTimes(hbClass));
+    const generatedTimes = getGeneratedTimes(hbClass);
+    hbClass.times = generatedTimes;
     return hbClass;
   });
  

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash-deep": "^2.0.0",
     "lru-cache": "^4.1.1",
     "moment": "^2.13.0",
+    "moment-recur": "^1.0.7",
     "mongoose": "^5.11.13",
     "mongoose-create-model": "0.0.2",
     "mongoose-cryptify": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,12 +2901,24 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
 
+moment-recur@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/moment-recur/-/moment-recur-1.0.7.tgz#4d5092af648aeded6afe5c13ef38c52901c99419"
+  integrity sha512-jpBQn6H62gCnEYjtYdLfK/VdPZHEXo1t8RrVItHVVS67SRvByyJBNBa3WQSGTe+8H0smcYO/79FYTA9LGMVdQw==
+  dependencies:
+    moment "<3.0.0"
+
 moment-timezone@^0.5.x:
   version "0.5.25"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"
   integrity sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==
   dependencies:
     moment ">= 2.9.0"
+
+moment@<3.0.0:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 "moment@>= 2.9.0", moment@^2.13.0, moment@^2.24.0:
   version "2.24.0"


### PR DESCRIPTION
Closes #138

ⓘ Related to [Pull Request #206](https://github.com/associatedemployers/safely/pull/206) on Safely front-end 

**_Action_**
Requesting to merge branch `feature/#138-add-get-generated-times-function-to-hub-class` into `master`

**_Description_**
Takes the `getGeneratedTimes()` function in the hub-class model on the front-end and makes it part of the backend in the `withAvailability` resource endpoint. Also adds additional functionality to return empty time objects for time blocks where participants exceed the class seat capacity.

